### PR TITLE
QoL improvement for package.json tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@arkecosystem/name",
-  "description": "Provides ... for ARK Core",
+  "description": "Provides ... for Ark Core",
   "version": "0.0.1",
   "contributors": [
     "Your Name <your@domain.io>"
@@ -10,8 +10,8 @@
   "main": "lib/index.js",
   "scripts": {
     "build:docs": "../../node_modules/.bin/jsdoc -c jsdoc.json",
-    "test": "ARK_ENV=test jest --forceExit",
-    "test:coverage": "ARK_ENV=test jest --coverage --forceExit",
+    "test": "ARK_ENV=test jest --runInBand --detectOpenHandles",
+    "test:coverage": "ARK_ENV=test jest --coverage --runInBand --detectOpenHandles",
     "test:debug": "ARK_ENV=test node --inspect-brk ../../node_modules/.bin/jest --runInBand --watch",
     "test:watch": "ARK_ENV=test jest --runInBand --watch",
     "test:watch:all": "ARK_ENV=test jest --runInBand --watchAll",


### PR DESCRIPTION
reflect core packages' testing scripts in package.json

```js    
    "test": "cross-env ARK_ENV=test jest --runInBand --detectOpenHandles",
    "test:coverage": "cross-env ARK_ENV=test jest --coverage --runInBand --detectOpenHandles",
    "test:debug": "cross-env ARK_ENV=test node --inspect-brk ../../node_modules/.bin/jest --runInBand --watch",
    "test:watch": "cross-env ARK_ENV=test jest --runInBand --watch",
    "test:watch:all": "cross-env ARK_ENV=test jest --runInBand --watchAll",
```
with cross-env removed, though it would still work because lerna bootstrap (if developed in a core clone under plugins or even packages)